### PR TITLE
Update release notes 1.1.4

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -5,6 +5,20 @@ owner: PCF Event Alerts
 
 These are release notes for PCF Event Alerts.
 
+##<a id="ver-1-1-3"></a> v1.1.4
+
+**Release Date:** June 5, 2018
+
+### <a id="features113"></a> Features
+
+New features and changes in this release:
+
+* Added configuration for insecure skip verify to notifications client. This fixes an issue that some users were unable to install Event Alerts when notifications requires https. 
+
+### <a id="known113"></a> Known Issues
+
+There are no known issues for this release.
+
 ##<a id="ver-1-1-3"></a> v1.1.3
 
 **Release Date:** May 17, 2018
@@ -18,7 +32,7 @@ New features and changes in this release:
 
 ### <a id="known113"></a> Known Issues
 
-There are no known issues for this release.
+Some users were unable to install Event Alerts when notifications requires https. This is resolved in 1.1.4.
 
 ##<a id="ver"></a> v1.1.2
 
@@ -33,3 +47,4 @@ Features included in this release:
 ### <a id="known"></a> Known Issues
 
 There are no known issues for this release.
+


### PR DESCRIPTION
1.1.4:
Added configuration for insecure skip verify to notifications client. This fixes an issue that some users were unable to install Event Alerts when notifications requires https. 

1.1.3:
Known issue: some users were unable to install Even Alerts when notifications requires https. This is resolved in 1.1.4