### PR TITLE
Add MySQL compatibility chart and install guide

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -56,6 +56,11 @@ The following table provides version and version-support information about PCF E
     <tr>
         <td>Compatible Pivotal Cloud Foundry Healthwatch version(s)</td>
         <td>1.2</td>
+    </tr>
+    <tr>
+        <td>MySQL</td>
+        <td>MySQL 5.7+ or MySQL for PCF v2.0+</td>
+    </tr>
     <tr>
         <td>IaaS support</td>
         <td>AWS, Azure, GCP, OpenStack, and vSphere</td>

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -13,7 +13,7 @@ You must have the following in order to install PCF Event Alerts:
 + PAS v2.1.x deployed with the following:
   + `Email Notifications` enabled with SMTP server configured.
   + `Notifications Errand` and `Notifications UI Errand` run.
-+ MySQL for PCF v2 or external MySQL credentials
++ MySQL for PCF v2 or external MySQL (version 5.7+) credentials
   <p class="note"><strong>Note:</strong> You cannot use a MariaDB database because it cannot set a <code>DATETIME</code> column to <code>CURRENT_TIMESTAMP</code>.
   For more information, see <a href="https://jira.mariadb.org/browse/MCOL-1039"> DATE / DATETIME should support CURRENT\_TIMESTAMP</a> the MariaDB ColumnStore issues.</p>
 + If you want notifications sent to Slack channels, a Slack account


### PR DESCRIPTION
- MySQL version less than 5.7 does not support multiple triggers for a
single table

[#163075222]

Signed-off-by: Rachel Heaton <rheaton@pivotal.io>