### PR TITLE
update docs for eva unsubscribe [#165643286]

### DIFF
--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -171,9 +171,6 @@ To subscribe a target to one or more alert topics, do the following:
 
     <pre class="terminal">$ cf eva-subscribe user-email healthwatch --all</pre>
 
-    <p class="note"><strong>Note:</strong> If you subscribe to <code>all</code> topics from a publisher, you cannot subsequently subscribe to, or unsubscribe from,
-    a single topic from that publisher. That is, you must subscribe to a specific topic or topics, or subscribe to <code>all</code>.</p>
-
 ##<a id='unsubscribe_topics'></a>Unsubscribe from Alert Topics
 
 To unsubscribe a target from alert topics, do the following:
@@ -184,6 +181,10 @@ To unsubscribe a target from alert topics, do the following:
         ```
         cf eva-unsubscribe TARGET-NAME PUBLISHER --topics TOPIC1,TOPIC2,...
         ```
+        
+    <p class="note"><strong>Note:</strong> If you subscribe to <code>all</code> topics from a publisher, you can subsequently unsubscribe from
+    a single topic from that publisher using the above command. If you want to resubscribe to the topic, run <code>cf eva-subscribe TAEGET-NAME PUBLISHER --topics TOPIC1</code>.</p>
+    
     * To unsubscribe a target from all topics from a publisher:
 
         ```


### PR DESCRIPTION
@snneji This change needs to be in 1.2 patch as well (unreleased). 
And we need to add a release notes for 1.2 patch:


---
New Feature:
* Previously, when you were subscribed to `--all` topics, you couldn't selectively unsubscribe from individual topics. This change allows for selectively unsubscribing.


---
Could you put the above release notes in 1.2 docs? Thanks.